### PR TITLE
Use locale for MessageFormat

### DIFF
--- a/tasks/inc/resourceFile.js
+++ b/tasks/inc/resourceFile.js
@@ -49,7 +49,7 @@ module.exports = {
     var locale = this.getLocaleName(fileName);
     var propObj = this.getMessageObj(fileName, format);
 
-    var mf = new MessageFormat();
+    var mf = new MessageFormat(locale);
 
     var mfunc = mf.compile(propObj);
     return mfunc;


### PR DESCRIPTION
Locale must be used when initializing MessageFormat() to get correct locale functions in the compiled file.